### PR TITLE
chore(ci): pin purcell/setup-emacs to v7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Emacs
-        uses: purcell/setup-emacs@master
+        uses: purcell/setup-emacs@v7.0
         with:
           version: ${{ matrix.emacs_version }}
 
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Emacs
-        uses: purcell/setup-emacs@master
+        uses: purcell/setup-emacs@v7.0
         with:
           version: '29.1'
 


### PR DESCRIPTION
## Summary
- Pin `purcell/setup-emacs` action from `@master` to `@v7.0`

## Why
Using `@master` for GitHub Actions is risky:
- Upstream changes can break CI without notice
- No audit trail of tested versions
- Potential security risk if master is compromised

## Changes
- `.github/workflows/ci.yml`: `@master` → `@v7.0` (2 occurrences)